### PR TITLE
.gitignore: add .bak and .sqlite3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,9 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Text backup files
+*.bak
+
+# Database
+*.sqlite3


### PR DESCRIPTION
Added .bak and .sqlite3 patterns to .gitignore file to ignore text backup files and SQLite3 database files.